### PR TITLE
Forbedringer i fetch-keystores-skriptet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,32 @@ curl -fsLo /usr/local/bin/rr https://github.com/navikt/bomlo-cli/releases/latest
 ### 2. Hente secrets og generere config
 Verktøyet trenger credentials mot Kafka-clusteret for å kunne utføre kommandoer, til dette brukes sertifikater.
 
-Skriptet som henter sertifikater krever navnet på en secret i prod-gcp, og henter også sertifikater for dev hvis man angir
-navnet på en secret i dev-gcp.
+Skriptet som henter sertifikater krever navnet på en secret i miljøet du skal operere mot, prod-gcp eller dev-gcp.
 
+Du må være logget på k8s-clusteret.
 
-Finn navn på en aiven-secret fra **prod-gcp**:
+Finn navn på en aiven-secret fra **prod-gcp** eller **dev-gcp**:
 ```shell
 kubectl get secret -n=tbd | grep aiven-
 ```
-Gjenta eventuelt for **dev-gcp**.
 
-Kjør kommandoen:
+Kjør kommandoen, enten mot prod-gcp:
 ```shell
-./fetch-keystores.sh <name-of-prod-secret> <optional-name-of-dev-secret>
+./fetch-keystores.sh <name-of-prod-secret>
 ```
 
-Det lages automatisk en fil kalt `config/prod-aiven.properties`, og eventuelt en `config/dev-aiven.properties`.
+Eller mot dev-gcp:
+```shell
+./fetch-keystores.sh --dev <name-of-dev-secret>
+```
+
+Det lages automatisk en fil med navn for miljøet man går mot, enten `config/prod-aiven.properties` eller `config/dev-aiven.properties`.
 
 
-### 3. Koble opp mot naisdevice-gateway `aiven-prod`
+### 3. Går du mot prod? Koble opp mot naisdevice-gateway `aiven-prod`
 
 Selv om foregående kommandoer for å liste og hente secrets fungerer fint uten denne er selve CLI-ets kommandoer
-avhengige av den.
+avhengige av den. Mot dev-gcp er det ikke nødvendig å koble opp mot gateway.
 
 ### 4. Kjøre kommandoer
 

--- a/fetch-keystores.sh
+++ b/fetch-keystores.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 alias k=kubectl
 function kx() {
-    k config use-context $1
+    k config use-context "$1"
 }
 
 function checkKeystore() {
@@ -16,7 +16,7 @@ function checkKeystore() {
   then
       echo Keystore is corrupt, or bad password
   else
-      echo Keystore $1 seem to be ok ...
+      echo Keystore "$1" seem to be ok ...
   fi
 }
 
@@ -25,7 +25,7 @@ function checkTruststore() {
   then
       echo Truststore is corrupt, or bad password
   else
-  	echo Trustore $1 seem to be ok ...
+  	echo Trustore "$1" seem to be ok ...
   fi
 }
 
@@ -38,12 +38,14 @@ function getSecrets() {
     checkTruststore "$3"
 
     echo "Writing properties to $4"
-    echo "config = aiven" > "$4"
-    echo "aiven.brokers.url = $BROKERS" >> "$4"
-    echo "aiven.truststore.path = $(pwd)/$3" >> "$4"
-    echo "aiven.truststore.password = changeme" >> "$4"
-    echo "aiven.keystore.path = $(pwd)/$2" >> "$4"
-    echo "aiven.keystore.password = changeme" >> "$4"
+    {
+        echo "config = aiven"
+        echo "aiven.brokers.url = $BROKERS"
+        echo "aiven.truststore.path = $(pwd)/$3"
+        echo "aiven.truststore.password = changeme"
+        echo "aiven.keystore.path = $(pwd)/$2"
+        echo "aiven.keystore.password = changeme"
+    } > "$4"
 }
 
 if test "$#" -eq 0; then
@@ -53,9 +55,9 @@ if test "$#" -eq 0; then
 fi
 
 kx prod-gcp
-getSecrets $1 $KEYTSTORE_PROD_NAME $TRUSTORE_PROD_NAME "$SCRIPT_DIR/config/prod-aiven.properties"
+getSecrets "$1" $KEYTSTORE_PROD_NAME $TRUSTORE_PROD_NAME "$SCRIPT_DIR/config/prod-aiven.properties"
 
 if ! test -z "$2"; then
     kx dev-gcp
-    getSecrets $2 $KEYTSTORE_DEV_NAME $TRUSTORE_DEV_NAME "$SCRIPT_DIR/config/dev-aiven.properties"
+    getSecrets "$2" $KEYTSTORE_DEV_NAME $TRUSTORE_DEV_NAME "$SCRIPT_DIR/config/dev-aiven.properties"
 fi

--- a/fetch-keystores.sh
+++ b/fetch-keystores.sh
@@ -1,8 +1,8 @@
 #!/bin/zsh
 
-KEYTSTORE_PROD_NAME=aiven-prod-keystore.p12
+KEYSTORE_PROD_NAME=aiven-prod-keystore.p12
 TRUSTORE_PROD_NAME=aiven-prod-truststore.jks
-KEYTSTORE_DEV_NAME=aiven-dev-keystore.p12
+KEYSTORE_DEV_NAME=aiven-dev-keystore.p12
 TRUSTORE_DEV_NAME=aiven-dev-truststore.jks
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
@@ -59,9 +59,9 @@ if test "$#" -eq 0; then
 fi
 
 kx prod-gcp
-getSecrets "$1" $KEYTSTORE_PROD_NAME $TRUSTORE_PROD_NAME "$SCRIPT_DIR/config/prod-aiven.properties"
+getSecrets "$1" $KEYSTORE_PROD_NAME $TRUSTORE_PROD_NAME "$SCRIPT_DIR/config/prod-aiven.properties"
 
 if ! test -z "$2"; then
     kx dev-gcp
-    getSecrets "$2" $KEYTSTORE_DEV_NAME $TRUSTORE_DEV_NAME "$SCRIPT_DIR/config/dev-aiven.properties"
+    getSecrets "$2" $KEYSTORE_DEV_NAME $TRUSTORE_DEV_NAME "$SCRIPT_DIR/config/dev-aiven.properties"
 fi

--- a/fetch-keystores.sh
+++ b/fetch-keystores.sh
@@ -6,11 +6,6 @@ KEYSTORE_DEV_NAME=aiven-dev-keystore.p12
 TRUSTORE_DEV_NAME=aiven-dev-truststore.jks
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-alias k=kubectl
-function kx() {
-    k config use-context "$1"
-}
-
 function checkKeystore() {
   if ! keytool -list -v -keystore "$1" -storepass changeme -storetype PKCS12 > /dev/null;
   then
@@ -52,16 +47,24 @@ function getSecrets() {
     } > "$filename"
 }
 
-if test "$#" -eq 0; then
-    echo "Usage: $0 <prod secret name> [<dev secret name>]"
-    echo "You must provide prod secret name."
-    exit 1
-fi
+function validateArgs() {
+    if test -z "$1"; then
+        echo "Usage: $ZSH_ARGZERO [--dev] <secret name>"
+        echo "You must provide secret name."
+        exit 1
+    fi
+}
 
-kx prod-gcp
-getSecrets "$1" $KEYSTORE_PROD_NAME $TRUSTORE_PROD_NAME "$SCRIPT_DIR/config/prod-aiven.properties"
+declare kontext=prod-gcp
+function k() {
+    kubectl --context $kontext "$@"
+}
 
-if ! test -z "$2"; then
-    kx dev-gcp
+if test "$1" = --dev; then
+    validateArgs "$2"
+    kontext=dev-gcp
     getSecrets "$2" $KEYSTORE_DEV_NAME $TRUSTORE_DEV_NAME "$SCRIPT_DIR/config/dev-aiven.properties"
+else
+    validateArgs "$1"
+    getSecrets "$1" $KEYSTORE_PROD_NAME $TRUSTORE_PROD_NAME "$SCRIPT_DIR/config/prod-aiven.properties"
 fi


### PR DESCRIPTION
En del er fikser shellcheck mente burde gjøres, og så er det to funksjonelle endringer:

- henter keystores uten å bytte global kubectl-context.
- - Begrunnelse: like greit å la den "globale" context forbli urørt, og det blir en kommando mindre å kjøre.
- henter enten fra prod eller dev, ikke fra begge i samme kommando.
- - Begrunnelse: slippe at man henter secrets fra prod når man bare skal gjøre ting i dev.